### PR TITLE
Revert "manifest: remove external/connectivity"

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -50,6 +50,7 @@
   <project path="external/bouncycastle" name="CyanogenMod/android_external_bouncycastle" groups="pdk" />
   <project path="external/brctl" name="CyanogenMod/android_external_brctl" />
   <project path="external/busybox" name="CyanogenMod/android_external_busybox" />
+  <project path="external/connectivity" name="CyanogenMod/android_external_connectivity" />
   <project path="external/curl" name="CyanogenMod/android_external_curl" />
   <project path="external/dhcpcd" name="CyanogenMod/android_external_dhcpcd" groups="pdk-cw-fs,pdk-fs" />
   <project path="external/dnsmasq" name="CyanogenMod/android_external_dnsmasq" groups="pdk" />


### PR DESCRIPTION
- The original commit message was misleading, this is a CAF repo
  and is needed to build libcnefeatureconfig for most recent qcom SoCs
- It no longer depends on libstlport

This reverts commit 2ff368fe01b5f64c04863f90c83f6e0f4b8f5ee0.

Change-Id: I1690d32a76e1cbf8b847fe04a926de964fd8cb5a
